### PR TITLE
 Hyperlink DOIs to new, preferred resolver 

### DIFF
--- a/MassBank-Project/MassBank/src/main/java/massbank/RecordDisplay.java
+++ b/MassBank-Project/MassBank/src/main/java/massbank/RecordDisplay.java
@@ -259,14 +259,14 @@ public class RecordDisplay extends HttpServlet {
 //				    	value			= value.replaceAll(PMID, "<a href=\"http:\\/\\/www.ncbi.nlm.nih.gov/pubmed/" + id + "?dopt=Citation\" target=\"_blank\">" + PMID + "</a>");
 //				    }
 //				    if(matcher_doiUrl.matches()){
-//				    	// link http://dx.doi.org/<doi> url
+//				    	// link https://doi.org/<doi> url
 //				    	String doiUrl	= value.substring(matcher_doiUrl.start(1), matcher_doiUrl.end(1));
 //				    	value			= value.replaceAll(doiUrl, "<a href=\"" + doiUrl + "\" target=\"_blank\">" + doiUrl + "</a>");
 //				    } else 
 //				    if(matcher_doi.matches()){
 //				    	// link doi
 //				    	String doi	= value.substring(matcher_doi.start(1), matcher_doi.end(1));
-//				    	value			= value.replaceAll(doi, "<a href=\"http:\\/\\/dx.doi.org/" + doi + "\" target=\"_blank\">" + doi + "</a>");
+//				    	value			= value.replaceAll(doi, "<a href=\"https:\\/\\/doi.org/" + doi + "\" target=\"_blank\">" + doi + "</a>");
 //				    }
 //					
 //				    //sb.append(tag + ": " + value + "\n");

--- a/MassBank-Project/MassBank/src/main/java/massbank/RecordDisplay.java
+++ b/MassBank-Project/MassBank/src/main/java/massbank/RecordDisplay.java
@@ -244,7 +244,7 @@ public class RecordDisplay extends HttpServlet {
 //				case "PUBLICATION":
 //					String regex_pmid	= "PMID:[ ]?\\d{8,8}";
 //					String regex_doi	= "10\\.\\d{3,9}\\/[\\-\\._;\\(\\)\\/:a-zA-Z0-9]+[a-zA-Z0-9]";
-//					String regex_doiUrl	= "http\\:\\/\\/doi\\.org\\/" + regex_doi;
+//					String regex_doiUrl	= "https?\\:\\/\\/(dx\\.)?doi\\.org\\/" + regex_doi;
 //					Pattern pattern_pmid	= Pattern.compile(".*" + "(" + regex_pmid	+ ")" + ".*");
 //				    Matcher matcher_pmid	= pattern_pmid.matcher(value);
 //				    Pattern pattern_doi		= Pattern.compile(".*" + "(" + regex_doi	+ ")" + ".*");

--- a/MassBank-Project/MassBank/src/main/webapp/RecordDisplay.jsp
+++ b/MassBank-Project/MassBank/src/main/webapp/RecordDisplay.jsp
@@ -271,7 +271,7 @@
 		case "PUBLICATION":
 			String regex_pmid	= "PMID:[ ]?\\d{8,8}";
 			String regex_doi	= "10\\.\\d{3,9}\\/[\\-\\._;\\(\\)\\/:a-zA-Z0-9]+[a-zA-Z0-9]";
-			String regex_doiUrl	= "http\\:\\/\\/doi\\.org\\/" + regex_doi;
+			String regex_doiUrl	= "https?\\:\\/\\/(dx\\.)?doi\\.org\\/" + regex_doi;
 			Pattern pattern_pmid	= Pattern.compile(".*" + "(" + regex_pmid	+ ")" + ".*");
 		    Matcher matcher_pmid	= pattern_pmid.matcher(value);
 		    Pattern pattern_doi		= Pattern.compile(".*" + "(" + regex_doi	+ ")" + ".*");

--- a/MassBank-Project/MassBank/src/main/webapp/RecordDisplay.jsp
+++ b/MassBank-Project/MassBank/src/main/webapp/RecordDisplay.jsp
@@ -286,14 +286,14 @@
 		    	value			= value.replaceAll(PMID, "<a href=\"http:\\/\\/www.ncbi.nlm.nih.gov/pubmed/" + id + "?dopt=Citation\" target=\"_blank\">" + PMID + "</a>");
 		    }
 		    if(matcher_doiUrl.matches()){
-		    	// link http://dx.doi.org/<doi> url
+		    	// link https://doi.org/<doi> url
 		    	String doiUrl	= value.substring(matcher_doiUrl.start(1), matcher_doiUrl.end(1));
 		    	value			= value.replaceAll(doiUrl, "<a href=\"" + doiUrl + "\" target=\"_blank\">" + doiUrl + "</a>");
 		    } else 
 		    if(matcher_doi.matches()){
 		    	// link doi
 		    	String doi	= value.substring(matcher_doi.start(1), matcher_doi.end(1));
-		    	value			= value.replaceAll(doi, "<a href=\"http:\\/\\/dx.doi.org/" + doi + "\" target=\"_blank\">" + doi + "</a>");
+		    	value			= value.replaceAll(doi, "<a href=\"https:\\/\\/doi.org/" + doi + "\" target=\"_blank\">" + doi + "</a>");
 		    }
 			
 		    //sb.append(tag + ": " + value + "\n");

--- a/old_massbank_sources/Tomcat/webapps/ROOT/MassBank/jsp/index.jsp
+++ b/old_massbank_sources/Tomcat/webapps/ROOT/MassBank/jsp/index.jsp
@@ -248,7 +248,7 @@ MassBank.jp と同様に NORMAN MassBank からでも常に最新データにア
 <p class="p_dbsammary separate">
 MassBank は、<a href="http://biosciencedbc.jp/" target="_blank">NBDC-JST</a> によるライフサイエンスデータベース統合化推進プログラムの支援を受けています（2011－2013）。<br />
 MassBank は、<a href="http://www.mssj.jp/index-jp.html" target="_blank">日本質量分析学会</a> の公式データベースです。<br />
-MassBank をご利用された方は論文 (<a href="http://dx.doi.org/10.1002/jms.1777" target="_blank">DOI</a>) を引用してください。
+MassBank をご利用された方は論文 (<a href="https://doi.org/10.1002/jms.1777" target="_blank">DOI</a>) を引用してください。
 </p>
 <p />
 <!--ここまで▲データベースサービス　ショートカットボタン一覧-->
@@ -419,7 +419,7 @@ From NORMAN MassBank as well as MassBank.jp, users are accessible to all the lat
 <p class="p_dbsammary separate">
 MassBank is financially suported from <a href="http://biosciencedbc.jp/?lng=en" target="_blank">National Bioscience Database Center, Japan Science and Technology Agency</a> (2011-2013).<br />
 <a href="http://www.mssj.jp/index.html" target="_blank">The Mass Spectorometry Society of Japan</a> officially supports MassBank.<br />
-Please cite the article (<a href="http://dx.doi.org/10.1002/jms.1777" target="_blank">DOI</a>) when using MassBank.
+Please cite the article (<a href="https://doi.org/10.1002/jms.1777" target="_blank">DOI</a>) when using MassBank.
 </p>
 <p />
 <!--ed▲mass spectrum database shortcut button list-->


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!