### PR TITLE
Add cahing of maven dependencies to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: java
+
+cache:
+  directories:
+  - $HOME/.m2
+  
 script: cd MassBank-Project && mvn package 
 


### PR DESCRIPTION
Since Travis-CI times out during mvn dependency downloads, as mentioned in #136