### PR TITLE
Add link to external visualisation tool

### DIFF
--- a/MassBank-Project/MassBank/src/main/webapp/RecordDisplay.jsp
+++ b/MassBank-Project/MassBank/src/main/webapp/RecordDisplay.jsp
@@ -553,6 +553,9 @@
 						<img src="image/not_available_s.gif" width="200" height="200" style="margin:0px;">
 					<%}%></td>
 			</tr>
+			<tr>
+			<td><a href="https://metabolomics-usi.ucsd.edu/spectrum/?usi=mzdata:MASSBANK:<%=accession%>" target=”_blank”>metabolomics-usi visualisation</a></td>
+			</tr>
 		</table>
 		<%}%>		
 <hr size="1">

--- a/MassBank-Project/MassBank/src/main/webapp/RecordDisplay.jsp
+++ b/MassBank-Project/MassBank/src/main/webapp/RecordDisplay.jsp
@@ -554,7 +554,7 @@
 					<%}%></td>
 			</tr>
 			<tr>
-			<td><a href="https://metabolomics-usi.ucsd.edu/spectrum/?usi=mzdata:MASSBANK:<%=accession%>" target=”_blank”>metabolomics-usi visualisation</a></td>
+			<td><a href="https://metabolomics-usi.ucsd.edu/spectrum/?usi=mzspec:MASSBANK:<%=accession%>" target=”_blank”>metabolomics-usi visualisation</a></td>
 			</tr>
 		</table>
 		<%}%>		


### PR DESCRIPTION
Prototype for Link out to external Visualisation via the https://metabolomics-usi.ucsd.edu/
Closes https://github.com/mwang87/MetabolomicsSpectrumResolver/issues/62
Improvements could be a nicer element (Link out icon ?) 
Currently an example is e.g. https://msbi.ipb-halle.de/MassBank/RecordDisplay.jsp?id=UA002901
Yours, Steffen