### PR TITLE
fix: rename compound view

### DIFF
--- a/modules/sql/docker-entrypoint-initdb.d/01-init-massbank.sql
+++ b/modules/sql/docker-entrypoint-initdb.d/01-init-massbank.sql
@@ -292,7 +292,7 @@ create view msms_spectrum_peak as select
       PEAK.PK_PEAK_INTENSITY as intensity
 from PEAK;
 
-create view compound as select
+create view ms_compound as select
       COMPOUND.ID as compound_id,
       COMPOUND.CH_FORMULA as formula,
       COMPOUND.CH_EXACT_MASS as exactmass,


### PR DESCRIPTION
Rename view `compound` into `ms_compound` which avoids overwriting the `COMPOUND` table on case insensitive systems (Windows).