### PR TITLE
Make the schema.org resolve

### DIFF
--- a/MassBank-Project/MassBank-web/src/main/webapp/Contents.jsp
+++ b/MassBank-Project/MassBank-web/src/main/webapp/Contents.jsp
@@ -221,7 +221,7 @@
 		</div>
 	</div>
 	
-	<main context="http://schema.org" property="schema:about" resource="https://massbank.eu/MassBank/RecordIndex" typeof="schema:DataCatalog" >
+	<main context="https://schema.org" property="schema:about" resource="https://massbank.eu/MassBank/RecordIndex" typeof="schema:DataCatalog" >
 		<div style="display:none" property="schema:citation" typeof="schema:ScholarlyArticle">
 			<div property="schema:name">Horai, Arita, Kanaya, Nihei, Ikeda, Suwa, Ojima, Tanaka, Tanaka, Aoshima, Oda, Kakazu, Kusano, Tohge, Matsuda, Sawada, Hirai, Nakanishi, Ikeda, Akimoto, Maoka, Takahashi, Ara, Sakurai, Suzuki, Shibata, Neumann, Iida, Tanaka, Funatsu, Matsuura, Soga, Taguchi, Saito, Nishioka. MassBank: a public repository for sharing mass spectral data for life sciences. Journal of mass spectrometry. 2010 Jul;45(7):703-14. doi: 10.1002/jms.1777.</div>
 			<div property="schema:headline">MassBank: a public repository for sharing mass spectral data for life sciences.</div>


### PR DESCRIPTION
The http://schema.org has an `301 Moved Permanently` to https://schema.org/ which confuses some software,  see https://github.com/IFB-ElixirFr/FAIR-checker/issues/82#issuecomment-1261072300